### PR TITLE
Fix VHDL syntax error in pp_soc_memory process

### DIFF
--- a/soc/pp_soc_memory.vhd
+++ b/soc/pp_soc_memory.vhd
@@ -81,6 +81,6 @@ begin
 				end if;
 			end if;
 		end if;
-	end process clk;
+	end process;
 
 end architecture behaviour;


### PR DESCRIPTION
That error prevented simulating the design with GHDL:

```
vendor/potato/soc/pp_soc_memory.vhd:84:20:error: end label for an unlabeled declaration or statement
ghdl-mcode:error: importation has failed due to compilation error
```